### PR TITLE
Fix JSDoc keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ The `deBug` function serves two debugging purposes; the first is adding to the l
  *   function deBug()
  *   Writes responses and outputs to cloudpage for debugging code
  *
- *    @peram action {String} Identifier for what is being debugged
- *    @peram response {Object} Output/Response to Stringify and Write
- *    @peram logExtKey {String} External Key of Logging Data Extension
- *    @peram debug {Number} toggles debugging function to write values to cloudpage
+ *    @param action {String} Identifier for what is being debugged
+ *    @param response {Object} Output/Response to Stringify and Write
+ *    @param logExtKey {String} External Key of Logging Data Extension
+ *    @param debug {Number} toggles debugging function to write values to cloudpage
  *    @return Debugging Identifier, Stringified Response, line breaks around output
  *
  ***********************************************/
@@ -61,8 +61,8 @@ function deBug(action, response, logExtKey, debug) {
  *   function addLog()
  *   Pushes logging object to array to be written to a Data Extension
  *   
- *    @peram obj {Object} logging object that matches the data extension
- *    @peram logExtKey {String} External Key to log records to
+ *    @param obj {Object} logging object that matches the data extension
+ *    @param logExtKey {String} External Key to log records to
  *    
  ***********************************************/
 function addLog(obj, logExtKey) {
@@ -76,7 +76,7 @@ function addLog(obj, logExtKey) {
  * function getDataExtensionKey()
  * Retieves the External Key for a SFMC Data Extension
  * 
- * @peram name {String} Name of the data extension
+ * @param name {String} Name of the data extension
  * @return {string} External Key of data extension
  * 
  */

--- a/codeResource.js
+++ b/codeResource.js
@@ -97,8 +97,8 @@ function wsRead(logKey) {
  *   Takes Objects that are Name/Value pairs {Name: "Key", Value: "Value"} and
  *   normalizes them to a standard JSON object {key: "value"}
  *
- *    @peram {arr} array to normalize
- *    @peram {prop} property key of Array
+ *    @param {arr} array to normalize
+ *    @param {prop} property key of Array
  *
  *    @output Array of normalized JSON object
  *
@@ -125,7 +125,7 @@ function formatResult(arr, prop) {
  *   function getFieldNames()
  *   Gets all columns from a SOAP Object
  *
- *    @peram {deName} Name of DataExtension to get columns
+ *    @param {deName} Name of DataExtension to get columns
  *
  *    @output {array} array of fields
  *


### PR DESCRIPTION
For JSDoc, the keyword needed in these comment blocks is `@param`. I can’t find any references to `@peram` so I assume this is just a mistake but feel free to ignore if I’m incorrect.

See https://jsdoc.app/tags-param.html